### PR TITLE
debian: fix architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: De-bloat stock image
-      run: |
-        rm -r /run/host/usr/share/dotnet
-        rm -r /run/host${{ runner.tool_cache }}
-
     - name: Install needed packages
       run: apt update && apt install dpkg-dev build-essential debhelper -y
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: De-bloat stock image
-        run: |
-          rm -r /run/host/usr/share/dotnet
-          rm -r /run/host${{ runner.tool_cache }}
-
       - name: Install needed packages
         run: apt update && apt install dpkg-dev build-essential debhelper -y
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Rules-Requires-Root: binary-targets
 
 Package: base-files
 Provides: base, usr-is-merged
-Architecture: any
+Architecture: all
 Pre-Depends: awk
 Depends: ${misc:Depends}
 Essential: yes


### PR DESCRIPTION
This package does not contain any binary files, so the `architecture` should be set to `all` to mark it as architecture-independent.

Related to https://github.com/Vanilla-OS/live-iso/issues/87.